### PR TITLE
Document the WADFileReader class with JSDoc comments

### DIFF
--- a/wadfilereader.js
+++ b/wadfilereader.js
@@ -1,8 +1,19 @@
+/**
+ * A class for reading binary data from a WAD (Where's All the Data) file.
+ */
 class WADFileReader {
+  /**
+   * Creates a new instance of the WADFileReader class.
+   * @param {File} file - The File object representing the WAD file to be read.
+   */
   constructor(file) {
     this.file = file;
   }
-
+  /**
+   * Reads the contents of the WAD file asynchronously and returns an ArrayBuffer.
+   * @async
+   * @returns {Promise<ArrayBuffer>} A Promise that resolves to an ArrayBuffer containing the binary data of the WAD file.
+   */
   async readFile() {
     try {
       const arrayBuffer = await this.readFileAsArrayBuffer(this.file);
@@ -11,7 +22,11 @@ class WADFileReader {
       console.error("Error parsing WAD file:", error);
     }
   }
-
+  /**
+   * Reads the content of a given File object as an ArrayBuffer.
+   * @param {File} file - The File object to be read.
+   * @returns {Promise<ArrayBuffer>} A Promise that resolves to an ArrayBuffer containing the binary data of the file.
+   */
   readFileAsArrayBuffer(file) {
     return new Promise((resolve, reject) => {
       const reader = new FileReader();


### PR DESCRIPTION
Resolves issue #33

This pull request adds JSDoc comments to the WADFileReader class to improve code documentation and readability.

I've documented each method in the WADFileReader class using JSDoc format. This includes parameter types, return types, and brief descriptions of each method's functionality.