### PR TITLE
Fix wall segs disappearing

### DIFF
--- a/world/bsptraversal.js
+++ b/world/bsptraversal.js
@@ -2,8 +2,6 @@ class BSPTraversal {
   constructor(levels, subsector) {
     this.things = levels.things;
 
-    this.player = this.things[0];
-
     this.nodes = levels.nodes;
 
     this.subsector = subsector;
@@ -28,8 +26,8 @@ class BSPTraversal {
     const bsp = this.nodes[nodeID];
 
     const isOnLeft = this.isPointOnLeftSide(
-      this.player.xPosition,
-      this.player.yPosition,
+      gameEngine.player.x,
+      gameEngine.player.y,
       bsp
     );
 


### PR DESCRIPTION
Fix issue #44 

The wall segments disappeared as the world was navigated due to the player position used in the BSP tree traversal remaining constant. Thus as the player moved throughout the world, the updated player world location was not represented in the search for the player during the tree traversal. In other words, the initial spawn point of the player was the only location being searched for during the tree traversal.