### PR TITLE
Fix one pixel lines

### DIFF
--- a/render/wallrenderer.js
+++ b/render/wallrenderer.js
@@ -148,7 +148,7 @@ class WallRenderer {
     const color = this.colorGenerator.getColor(wallTexture, lightLevel);
 
     for (let x = xScreenV1; x <= xScreenV2; x++) {
-      const drawWallY1 = wallY1 - 1;
+      const drawWallY1 = wallY1;
       const drawWallY2 = wallY2;
 
       if (drawCeiling) {


### PR DESCRIPTION
The first Y coordinate of this column was subtracted by 1 which in one case led to a 1-pixel difference between two points which should have had a 0-pixel difference. 