### PR TITLE
Fix sprite orientation calculation

### DIFF
--- a/world/subsector.js
+++ b/world/subsector.js
@@ -190,7 +190,7 @@ class Subsector {
     // there is a rotation
     const angleToThing = gameEngine.player.angleTowardsVertex(thing);
     const tempAngle = angleToThing.subtract(thing.angle);
-    const rotation = Math.floor(((tempAngle.add(45 / 2).angle * 9) / 45) % 8);
+    const rotation = Math.floor((tempAngle.add(45 / 2).angle / 45) % 8);
 
     return {
       lump: spriteFrame.lump[rotation],


### PR DESCRIPTION
## Summary
- correct the rotation math in `chooseSpriteLump`

## Testing
- `node -e "require('./world/subsector.js')"`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6843a3b2c1948321a639a17b8df3e14c